### PR TITLE
Remove outdated Georepublic contact information

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Support
-    url: https://georepublic.info/
-    about: Looking for commercial support?
-    
+  - name: Discussions
+    url: https://github.com/orgs/gtt-project/discussions
+    about: Ask questions and share ideas with the community.
+  - name: Website
+    url: https://gtt-project.org
+    about: Learn more about the GTT Project.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at foss@georepublic.info. All
+reported by contacting the project maintainers listed in the
+[GTT Project GitHub organization](https://github.com/orgs/gtt-project/people). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,8 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project maintainers listed in the
-[GTT Project GitHub organization](https://github.com/orgs/gtt-project/people). All
+reported by contacting the project team at hello@gtt-project.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,18 @@ possible.
 
 ## Code of Conduct
 GTT Project has adopted a Code of Conduct that we expect project
-participants to adhere to. Please [read the full text](https://github.com/gtt-project/.github/blob/master/CODE_OF_CONDUCT.md)
+participants to adhere to. Please [read the full text](https://github.com/gtt-project/.github/blob/main/CODE_OF_CONDUCT.md)
 so that you can understand what actions will and will not be tolerated.
 
 ## Our Development Process
-We use GitHub to sync code to and from our internal repository. We'll use GitHub
-to track issues and feature requests, as well as accept pull requests.
+All development happens on GitHub. We use GitHub to track issues and feature
+requests, as well as accept pull requests.
 
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `develop`.
+1. Fork the repo and create your branch from its development branch
+   (`next` where it exists, otherwise the default branch).
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [georepublic]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,38 @@
-## Security
+# Security
 
-GTT Project takes the security of our software seriously, which includes all source code repositories managed through our [GitHub organization](https://github.com/gtt-project).
+The GTT Project takes the security of our software seriously, which includes
+all source code repositories managed through our
+[GitHub organization](https://github.com/gtt-project).
 
-If you believe you have found a security vulnerability in any GTT Project-managed repository, please report it to us as described below.
+If you believe you have found a security vulnerability in any GTT
+Project-managed repository, please report it to us as described below.
 
 ## Reporting Security Issues
 
-**Please do not report security vulnerabilities through public GitHub issues.** 
+**Please do not report security vulnerabilities through public GitHub issues
+or discussions.**
 
-Instead, please report them via email to [foss@georepublic.info](mailto:foss@georepublic.info). You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+Instead, please use GitHub's private vulnerability reporting: open the
+**Security** tab of the affected repository and choose
+**Report a vulnerability**. This creates a private advisory that only you and
+the maintainers can see. See GitHub's documentation on
+[privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+for details.
 
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+Please include the requested information listed below (as much as you can
+provide) to help us better understand the nature and scope of the possible
+issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+- Type of issue (e.g. SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
- 
+
 ## Preferred Languages
 
 We prefer all communications to be in English.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,9 @@ the maintainers can see. See GitHub's documentation on
 [privately reporting a security vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
 for details.
 
+If you cannot use GitHub's private reporting, you can also reach us by email
+at [hello@gtt-project.org](mailto:hello@gtt-project.org).
+
 Please include the requested information listed below (as much as you can
 provide) to help us better understand the nature and scope of the possible
 issue:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,19 +1,25 @@
 # GTT Project Support
-Feel free to send us questions to [foss@georepublic.info](mailto:foss@georepublic.info).
-You can also find more detailed information about GTT Project on our website: [https://gtt-project.org
-](https://gtt-project.org).
 
-If you’re looking for commercial support, find below a list of companies providing GTT Project development and consulting services.
+Questions, ideas and general discussion are welcome in the
+[GTT Project Discussions](https://github.com/orgs/gtt-project/discussions).
+You can also find more information about the GTT Project on our website:
+[https://gtt-project.org](https://gtt-project.org).
 
 ## Reporting Problems
-We use [GitHub issues](https://github.com/gtt-project) to track public bugs. Please ensure your description is clear and has sufficient instructions to be able to reproduce the issue. If possible please provide a minimal demo of the problem. Please follow these steps:
 
-- Search the issues to see if your problem has already been reported. If so, add any extra context you might have found, or at least indicate that you too are having the problem. This will help us prioritize common issues.
-- If your problem is unreported, create a new issue for it.
-- In your report include explicit instructions to replicate your issue. 
+We use [GitHub issues](https://github.com/gtt-project) to track public bugs.
+Please ensure your description is clear and has sufficient instructions to be
+able to reproduce the issue. If possible please provide a minimal demo of the
+problem. Please follow these steps:
 
-## Commercial Support
-For users who require professional support, development and consulting services, consider contacting any of the following developers or organizations, which have significantly contributed to the development of GTT Project:
+- Search the issues to see if your problem has already been reported. If so,
+  add any extra context you might have found, or at least indicate that you
+  too are having the problem. This will help us prioritize common issues.
+- If your problem is unreported, create a new issue for it in the repository
+  the problem belongs to.
+- In your report include explicit instructions to replicate your issue.
 
-- Georepublic: https://georepublic.info
-- [Contact us](mailto:mail@georepublic.info), if you think your name is missing.
+## Security Issues
+
+Please do not report security vulnerabilities through public issues or
+discussions. See [SECURITY.md](SECURITY.md) for how to report them privately.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,8 @@
 # GTT Project Support
 
 Questions, ideas and general discussion are welcome in the
-[GTT Project Discussions](https://github.com/orgs/gtt-project/discussions).
+[GTT Project Discussions](https://github.com/orgs/gtt-project/discussions),
+or by email at [hello@gtt-project.org](mailto:hello@gtt-project.org).
 You can also find more information about the GTT Project on our website:
 [https://gtt-project.org](https://gtt-project.org).
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,12 @@
 ## GTT Project
 
-... turns Redmine into a Location-based Task Manager.
+**Geo-Task-Tracker: open source plugins that turn [Redmine](https://www.redmine.org/) into a location-based task manager.**
+
+Locate issues as points, lines or polygons, show and filter them on a map,
+define project areas, and connect field data collection tools. Built on
+PostgreSQL/PostGIS and OpenLayers.
+
+- 🌏 Website: [gtt-project.org](https://gtt-project.org)
+- 🗺️ Core plugin: [`redmine_gtt`](https://github.com/gtt-project/redmine_gtt)
+- 💬 Community: [Discussions](https://github.com/orgs/gtt-project/discussions)
+- 🛟 Support: [SUPPORT.md](https://github.com/gtt-project/.github/blob/main/SUPPORT.md) · Security: [SECURITY.md](https://github.com/gtt-project/.github/blob/main/SECURITY.md)


### PR DESCRIPTION
Georepublic is no longer the maintainer of the GTT Project, but its contact details were still baked into the org-wide community files. This switches everything to GitHub-native channels:

- **SUPPORT.md**: questions go to [org Discussions](https://github.com/orgs/gtt-project/discussions) or hello@gtt-project.org; the Commercial Support section and `georepublic.info` addresses are removed
- **SECURITY.md**: vulnerability reports now use GitHub private vulnerability reporting (already enabled on all active repos in the org), with hello@gtt-project.org as fallback
- **CODE_OF_CONDUCT.md**: enforcement contact is hello@gtt-project.org
- **CONTRIBUTING.md**: branch guidance updated (`next`/default instead of `develop`), Code of Conduct link fixed from `master` to `main`
- **FUNDING.yml removed**: repos no longer show a Sponsor button pointing at github.com/sponsors/georepublic
- **Issue template contact links**: point at Discussions and gtt-project.org instead of georepublic.info
- **profile/README.md**: expanded org profile with tagline and links

After this PR, `grep -ri georepublic` over the repo returns nothing.
